### PR TITLE
fix: Move logic to server and add typechecking and better TS experience

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Install
         run: npm ci
 
+      - name: Typecheck
+        run: npm run typecheck
+
       - name: Build
         run: npm run build
 

--- a/build.config.ts
+++ b/build.config.ts
@@ -4,4 +4,31 @@ export default defineBuildConfig({
   rollup: {
     emitCJS: true,
   },
+  entries: ['src/module'],
+  declaration: true,
+  clean: true,
+  hooks: {
+    'build:done': ctx => {
+      // Copy types file to dist
+      const fs = require('fs');
+      const path = require('path');
+
+      const sourceTypes = path.join(ctx.options.rootDir, 'src', 'types.ts');
+      const targetTypes = path.join(ctx.options.outDir, 'types.d.ts');
+
+      if (fs.existsSync(sourceTypes)) {
+        fs.copyFileSync(sourceTypes, targetTypes);
+        console.log('✓ Copied types.ts to dist/types.d.ts');
+      }
+
+      // Add triple slash directive to the top of the file
+      const targetTypesMts = path.join(ctx.options.outDir, 'types.d.mts');
+      if (fs.existsSync(targetTypesMts)) {
+        const content = fs.readFileSync(targetTypesMts, 'utf8');
+        fs.writeFileSync(targetTypesMts, '/// <reference types="./types.d.ts" />\n\n');
+        fs.appendFileSync(targetTypesMts, content);
+        console.log('✓ Appended reference to types.d.ts to dist/types.d.mts');
+      }
+    },
+  },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@content-island/nuxt",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@content-island/nuxt",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@content-island/api-client": "^0.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "nuxt": "^3.17.5",
         "prettier": "^3.5.3",
         "pretty-quick": "^4.2.2",
-        "typescript": "^5.8.3"
+        "typescript": "^5.8.3",
+        "vue-tsc": "^2.2.10"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3815,6 +3816,35 @@
         "vue": "^3.0.0"
       }
     },
+    "node_modules/@volar/language-core": {
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.15.tgz",
+      "integrity": "sha512-3VHw+QZU0ZG9IuQmzT68IyN4hZNd9GchGPhbD9+pa8CVv7rnoOZwo7T8weIbrRmihqy3ATpdfXFnqRrfPVK6CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/source-map": "2.4.15"
+      }
+    },
+    "node_modules/@volar/source-map": {
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.15.tgz",
+      "integrity": "sha512-CPbMWlUN6hVZJYGcU/GSoHu4EnCHiLaXI9n8c9la6RaI9W5JHX+NqG+GSQcB0JdC2FIBLdZJwGsfKyBB71VlTg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@volar/typescript": {
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.15.tgz",
+      "integrity": "sha512-2aZ8i0cqPGjXb4BhkMsPYDkkuc2ZQ6yOpqwAuNwUoncELqoy5fRgOQtLR9gB0g902iS0NAkvpIzs27geVyVdPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.15",
+        "path-browserify": "^1.0.1",
+        "vscode-uri": "^3.0.8"
+      }
+    },
     "node_modules/@vue-macros/common": {
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/@vue-macros/common/-/common-1.16.1.tgz",
@@ -3975,6 +4005,17 @@
         "@vue/shared": "3.5.16"
       }
     },
+    "node_modules/@vue/compiler-vue2": {
+      "version": "2.7.16",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-vue2/-/compiler-vue2-2.7.16.tgz",
+      "integrity": "sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "de-indent": "^1.0.2",
+        "he": "^1.2.0"
+      }
+    },
     "node_modules/@vue/devtools-api": {
       "version": "6.6.4",
       "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
@@ -4043,6 +4084,31 @@
       "license": "MIT",
       "dependencies": {
         "rfdc": "^1.4.1"
+      }
+    },
+    "node_modules/@vue/language-core": {
+      "version": "2.2.10",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-2.2.10.tgz",
+      "integrity": "sha512-+yNoYx6XIKuAO8Mqh1vGytu8jkFEOH5C8iOv3i8Z/65A7x9iAOXA97Q+PqZ3nlm2lxf5rOJuIGI/wDtx/riNYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "~2.4.11",
+        "@vue/compiler-dom": "^3.5.0",
+        "@vue/compiler-vue2": "^2.7.16",
+        "@vue/shared": "^3.5.0",
+        "alien-signals": "^1.0.3",
+        "minimatch": "^9.0.3",
+        "muggle-string": "^0.4.1",
+        "path-browserify": "^1.0.1"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vue/reactivity": {
@@ -4234,6 +4300,13 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/alien-signals": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-1.0.13.tgz",
+      "integrity": "sha512-OGj9yyTnJEttvzhTUWuscOvtqxq5vrhF7vL9oS0xJ2mK0ItPYP1/y+vCFebfxoEyAz0++1AIwJ5CMr+Fk3nDmg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
@@ -5541,6 +5614,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/de-indent": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
+      "integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.1",
@@ -7043,6 +7123,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
     "node_modules/hookable": {
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
@@ -8542,6 +8632,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/muggle-string": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
+      "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nano-spawn": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/nano-spawn/-/nano-spawn-1.0.2.tgz",
@@ -9530,6 +9627,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -12961,6 +13065,23 @@
         "@vue/compiler-core": "^3.5.13",
         "esbuild": "*",
         "vue": "^3.5.13"
+      }
+    },
+    "node_modules/vue-tsc": {
+      "version": "2.2.10",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-2.2.10.tgz",
+      "integrity": "sha512-jWZ1xSaNbabEV3whpIDMbjVSVawjAyW+x1n3JeGQo7S0uv2n9F/JMgWW90tGWNFRKya4YwKMZgCtr0vRAM7DeQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/typescript": "~2.4.11",
+        "@vue/language-core": "2.2.10"
+      },
+      "bin": {
+        "vue-tsc": "bin/vue-tsc.js"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
       }
     },
     "node_modules/web-streams-polyfill": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "types": "./dist/types.d.mts",
   "exports": {
     ".": {
-      "types": "./dist/types.d.mts",
+      "types": "./dist/types.d.*",
       "import": "./dist/module.mjs",
       "require": "./dist/module.cjs"
     }
@@ -33,7 +33,8 @@
     "publish-packages": "changeset publish",
     "prelocal:publish": "npm run build && cd ./local-npm-registry && npm start",
     "local:publish": "changeset version && node local-npm-registry/publish.js changeset publish",
-    "prepare": "nuxt-module-build prepare && husky || echo 'Husky is not installed'"
+    "prepare": "nuxt-module-build prepare && husky || echo 'Husky is not installed'",
+    "typecheck": "vue-tsc --noEmit"
   },
   "dependencies": {
     "@content-island/api-client": "^0.8.0",
@@ -47,7 +48,8 @@
     "nuxt": "^3.17.5",
     "prettier": "^3.5.3",
     "pretty-quick": "^4.2.2",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "vue-tsc": "^2.2.10"
   },
   "lint-staged": {
     "**/*": "prettier --write --ignore-unknown"

--- a/src/module.ts
+++ b/src/module.ts
@@ -20,15 +20,15 @@ export default defineNuxtModule<ModuleOptions>({
     // Register server handlers
     addServerHandler({
       route: '/api/__content_island/content',
-      handler: resolve('./runtime/server/api/content.get.ts'),
+      handler: resolve('./runtime/server/api/content.get'),
     });
     addServerHandler({
       route: '/api/__content_island/contentlist',
-      handler: resolve('./runtime/server/api/contentlist.get.ts'),
+      handler: resolve('./runtime/server/api/contentlist.get'),
     });
     addServerHandler({
       route: '/api/__content_island/project',
-      handler: resolve('./runtime/server/api/project.get.ts'),
+      handler: resolve('./runtime/server/api/project.get'),
     });
 
     // Register plugin that adds the $contentIsland client to the Nuxt app

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,4 +1,4 @@
-import { addPlugin, createResolver, defineNuxtModule } from '@nuxt/kit';
+import { addPlugin, addServerHandler, createResolver, defineNuxtModule } from '@nuxt/kit';
 import type { ModuleOptions } from './models';
 
 export default defineNuxtModule<ModuleOptions>({
@@ -11,10 +11,28 @@ export default defineNuxtModule<ModuleOptions>({
   },
   setup(options, nuxt) {
     const { resolve } = createResolver(import.meta.url);
+
     // Module options only available in the server side config to keep the accessToken private
     // nuxt.options.runtimeConfig -> private runtime config
     // nuxt.options.runtimeConfig.public -> public runtime config
     nuxt.options.runtimeConfig.contentIsland = options;
+
+    // Register server handlers
+    addServerHandler({
+      route: '/api/__content_island/content',
+      handler: resolve('./runtime/server/api/content.get.ts'),
+    });
+    addServerHandler({
+      route: '/api/__content_island/contentlist',
+      handler: resolve('./runtime/server/api/contentlist.get.ts'),
+    });
+    addServerHandler({
+      route: '/api/__content_island/project',
+      handler: resolve('./runtime/server/api/project.get.ts'),
+    });
+
+    // Register plugin that adds the $contentIsland client to the Nuxt app
+    // and calls the server endpoints
     addPlugin(resolve('./runtime/plugin'));
   },
 });

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -1,23 +1,29 @@
-import { defineNuxtPlugin, useRuntimeConfig } from '#app';
-import { createClient } from '@content-island/api-client';
-import type { ModuleOptions } from '../models';
+import { defineNuxtPlugin } from '#app';
+import type { ApiClient } from '@content-island/api-client';
 
 export default defineNuxtPlugin(() => {
-  const config = useRuntimeConfig();
-  const options = config.contentIsland as ModuleOptions;
-  if (!options?.accessToken) {
-    console.error(
-      'Content Island token is not provided. Please set the' +
-        ' CONTENT_ISLAND_ACCESS_TOKEN environment variable in a `.env` file' +
-        ' in the root of your project OR add it in the' +
-        ' nuxt.config file under the `contentIsland.accessToken` option.'
-    );
-  }
-  const client = createClient(options);
+  const createApiMethod = (endpoint: 'content' | 'contentlist', raw: boolean = false) => {
+    return async (
+      args: Parameters<ApiClient[typeof endpoint extends 'content' ? 'getContent' : 'getContentList']>[0]
+    ) => {
+      const query = raw ? { raw: 'true', ...args } : { raw: 'false', ...args };
+      return await $fetch(`/api/__content_island/${endpoint}`, { query });
+    };
+  };
+
+  const proxyClient = {
+    getContent: createApiMethod('content' as const, false),
+    getContentList: createApiMethod('contentlist' as const, false),
+    getRawContent: createApiMethod('content' as const, true),
+    getRawContentList: createApiMethod('contentlist' as const, true),
+    getProject: async () => {
+      return await $fetch('/api/__content_island/project');
+    },
+  };
 
   return {
     provide: {
-      contentIsland: client,
+      contentIsland: proxyClient,
     },
   };
 });

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -1,23 +1,36 @@
 import { defineNuxtPlugin } from '#app';
-import type { ApiClient } from '@content-island/api-client';
+import type { ApiClient, Project, QueryParams } from '@content-island/api-client';
+
+// Local Model type for generics (not exported)
+type Model<Language = string> = {
+  id: string;
+  language?: Language;
+};
 
 export default defineNuxtPlugin(() => {
-  const createApiMethod = (endpoint: 'content' | 'contentlist', raw: boolean = false) => {
-    return async (
-      args: Parameters<ApiClient[typeof endpoint extends 'content' ? 'getContent' : 'getContentList']>[0]
-    ) => {
-      const query = raw ? { raw: 'true', ...args } : { raw: 'false', ...args };
-      return await $fetch(`/api/__content_island/${endpoint}`, { query });
-    };
-  };
-
-  const proxyClient = {
-    getContent: createApiMethod('content' as const, false),
-    getContentList: createApiMethod('contentlist' as const, false),
-    getRawContent: createApiMethod('content' as const, true),
-    getRawContentList: createApiMethod('contentlist' as const, true),
-    getProject: async () => {
-      return await $fetch('/api/__content_island/project');
+  const proxyClient: ApiClient = {
+    getContent: async <M extends Model = Model & Record<string, any>>(query: QueryParams<M>) => {
+      return $fetch<M>(`/api/__content_island/content`, {
+        query: { ...query, raw: 'false' },
+      }) satisfies ReturnType<ApiClient['getContent']>;
+    },
+    getContentList: async <M extends Model = Model & Record<string, any>>(query?: QueryParams<M>) => {
+      return $fetch<M[]>(`/api/__content_island/contentlist`, {
+        query: { ...query, raw: 'false' },
+      }) satisfies ReturnType<ApiClient['getContentList']>;
+    },
+    getRawContent: async <M extends Model = Model & Record<string, any>>(query: QueryParams<M>) => {
+      return $fetch(`/api/__content_island/content`, {
+        query: { ...query, raw: 'true' },
+      }) satisfies ReturnType<ApiClient['getRawContent']>;
+    },
+    getRawContentList: async <M extends Model = Model & Record<string, any>>(query?: QueryParams<M>) => {
+      return $fetch(`/api/__content_island/contentlist`, {
+        query: { ...query, raw: 'true' },
+      }) satisfies ReturnType<ApiClient['getRawContentList']>;
+    },
+    getProject: async (): Promise<Project> => {
+      return $fetch('/api/__content_island/project');
     },
   };
 

--- a/src/runtime/server/api/content.get.ts
+++ b/src/runtime/server/api/content.get.ts
@@ -1,0 +1,21 @@
+import { defineEventHandler, getQuery, type H3Event } from 'h3';
+import { getContentIslandClient } from '../plugins/client';
+
+export default defineEventHandler(async (event: H3Event) => {
+  const client = getContentIslandClient();
+  const { raw = 'false', contentType, ...filters } = getQuery(event);
+
+  const queryParams = {
+    contentType: contentType as string,
+    ...filters,
+  };
+
+  if (raw === 'true') {
+    const content = await client.getRawContent(queryParams);
+
+    return content;
+  }
+  const content = await client.getContent(queryParams);
+
+  return content;
+});

--- a/src/runtime/server/api/contentlist.get.ts
+++ b/src/runtime/server/api/contentlist.get.ts
@@ -1,0 +1,21 @@
+import { defineEventHandler, getQuery, type H3Event } from 'h3';
+import { getContentIslandClient } from '../plugins/client';
+
+export default defineEventHandler(async (event: H3Event) => {
+  const client = getContentIslandClient();
+  const { raw = 'false', contentType, ...filters } = getQuery(event);
+
+  const queryParams = {
+    contentType: contentType as string,
+    ...filters,
+  };
+
+  if (raw === 'true') {
+    const content = await client.getRawContentList(queryParams);
+
+    return content;
+  }
+  const content = await client.getContentList(queryParams);
+
+  return content;
+});

--- a/src/runtime/server/api/project.get.ts
+++ b/src/runtime/server/api/project.get.ts
@@ -1,0 +1,9 @@
+import { defineEventHandler } from 'h3';
+import { getContentIslandClient } from '../plugins/client';
+
+export default defineEventHandler(async () => {
+  const client = getContentIslandClient();
+  const project = await client.getProject();
+
+  return project;
+});

--- a/src/runtime/server/plugins/client.ts
+++ b/src/runtime/server/plugins/client.ts
@@ -1,12 +1,12 @@
 import { useRuntimeConfig } from '#imports';
-import { createClient, type ApiClient } from '@content-island/api-client';
+import { createClient, type ApiClient, type Options } from '@content-island/api-client';
 
 let client: ApiClient;
 export const getContentIslandClient = () => {
   if (client) return client;
 
   const config = useRuntimeConfig();
-  const options = config.contentIsland;
+  const options = config.contentIsland as Options;
 
   if (!options?.accessToken) {
     console.error(

--- a/src/runtime/server/plugins/client.ts
+++ b/src/runtime/server/plugins/client.ts
@@ -1,0 +1,22 @@
+import { useRuntimeConfig } from '#imports';
+import { createClient, type ApiClient } from '@content-island/api-client';
+
+let client: ApiClient;
+export const getContentIslandClient = () => {
+  if (client) return client;
+
+  const config = useRuntimeConfig();
+  const options = config.contentIsland;
+
+  if (!options?.accessToken) {
+    console.error(
+      'Content Island token is not provided. Please set the' +
+        ' CONTENT_ISLAND_ACCESS_TOKEN environment variable in a `.env` file' +
+        ' in the root of your project OR add it in the' +
+        ' nuxt.config file under the `contentIsland.accessToken` option.'
+    );
+  }
+
+  client = createClient(options);
+  return client;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,17 @@
+import type { ApiClient } from '@content-island/api-client';
+
+// Nuxt plugin augmentation to add $contentIsland to the Nuxt app
+declare module '#app' {
+  interface NuxtApp {
+    $contentIsland: ApiClient;
+  }
+}
+
+declare module '@vue/runtime-core' {
+  interface ComponentCustomProperties {
+    $contentIsland: ApiClient;
+  }
+}
+
+// Empty export is required to mark the file as a module
+export {};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "./.nuxt/tsconfig.json"
+  "extends": "./.nuxt/tsconfig.json",
+  "exclude": ["playground", "dist", "node_modules", ".nuxt"]
 }


### PR DESCRIPTION
## Moving logic to server

Before, the plugin was trying to access the private `runtimeConfig` in the client side, resulting in this kind of warning:

![image](https://github.com/user-attachments/assets/1ef5baa0-6085-4d88-939a-c28f155d6bd9)

By registering custom endpoints in the Nuxt server side, we keep the `runtimeConfig` really private. This will work in both an SSR context and a SSG context.

### Endpoints

I created 3 endpoints:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/ea7066c7-bc31-4c64-b74d-ab5f75a3a360" />

> [!NOTE]
> The files named with `.get.ts` is a convention in Nuxt to narrow the methods allowed for this endpoint to only accept `GET` requests. 

But the first 2 are reused for:

- [getContentList](https://docs.contentisland.net/client-api/get-content-list/)
- [getRawContentList](https://docs.contentisland.net/client-api/get-raw-content-list/)
- [getContent](https://docs.contentisland.net/client-api/get-content/)
- [getRawContent](https://docs.contentisland.net/client-api/get-raw-content/)

Later, inside each endpoint I'm consuming a standalone Content Island Client instantiated in `server/plugins/client.ts` and I'm using the **library** instead of the REST API.

## Plugin

The plugin is used both in the server and in the client, so it cannot reference the private `runtimeConfig`. Here we map the client methods to the registered server endpoints.

To make the request to the registered endpoints, I'm using `$fetch`, which is included in Nuxt, via `ofetch`.

## Types

I added this `proxyClient` thing but it used `ApiClient` as the type definition and for extra type safety, the methods are using `satisfies` which will trigger a type error if the types don't match in the future.

I also added the typechecking step in the CI and the command in the package.json

I tested the types both in the playground and in a separate app.





## Screenshots
| Screenshots |
|--------|
| <img width="809" alt="Screenshot 2025-06-30 at 19 17 45" src="https://github.com/user-attachments/assets/0bc3eecd-6aa6-4a38-9f6a-c525c2654991" /> <p align="center">Methods are correctly typed</p> |
| <img width="1191" alt="Screenshot 2025-06-30 at 21 06 35" src="https://github.com/user-attachments/assets/0d292ab6-c6bc-439c-8540-3cf04f36d47c" /> <p align="center">Autocompletion also shows the expected types</p> |
| <img width="384" alt="Screenshot 2025-06-30 at 21 07 18" src="https://github.com/user-attachments/assets/780f581f-6bea-4515-8191-bba85d2aafea" /> <p align="center">And the `$contentIsland` object matches the type used in the library</p> | 